### PR TITLE
Add Assert-VersionRequirement mock checks

### DIFF
--- a/Tests/Add-PASDiscoveredLocalAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredLocalAccount.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -91,6 +90,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
     }

--- a/Tests/Clear-PASDiscoveredLocalAccount.Tests.ps1
+++ b/Tests/Clear-PASDiscoveredLocalAccount.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -82,6 +81,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
+            }
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
             }
 
         }

--- a/Tests/Get-PASBYOKConfig.Tests.ps1
+++ b/Tests/Get-PASBYOKConfig.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -82,6 +81,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
+            }
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
             }
 
         }

--- a/Tests/Get-PASDiscoveredLocalAccount.Tests.ps1
+++ b/Tests/Get-PASDiscoveredLocalAccount.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -108,6 +107,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
     }

--- a/Tests/Get-PASDiscoveredLocalAccountActivity.Tests.ps1
+++ b/Tests/Get-PASDiscoveredLocalAccountActivity.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -90,6 +89,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
     }

--- a/Tests/Get-PASIPAllowList.Tests.ps1
+++ b/Tests/Get-PASIPAllowList.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -84,6 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
     }

--- a/Tests/Publish-PASDiscoveredLocalAccount.Tests.ps1
+++ b/Tests/Publish-PASDiscoveredLocalAccount.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -90,6 +89,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
+            }
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
             }
 
         }

--- a/Tests/Remove-PASDiscoveredLocalAccount.Tests.ps1
+++ b/Tests/Remove-PASDiscoveredLocalAccount.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -90,6 +89,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
     }

--- a/Tests/Set-PASIPAllowList.Tests.ps1
+++ b/Tests/Set-PASIPAllowList.Tests.ps1
@@ -49,7 +49,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         BeforeEach {
             $psPASSession.ExternalVersion = '0.0'
 
-            #TODO: Figure out how to include Assert-VersionRequirement in P Cloud function tests
             Mock Assert-VersionRequirement -MockWith {}
 
             Mock Invoke-PASRestMethod -MockWith {
@@ -118,6 +117,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'calls Assert-VersionRequirement once' {
+                Assert-MockCalled Assert-VersionRequirement -Times 1 -Exactly -Scope It
+            }
         }
 
         Context 'Output' {


### PR DESCRIPTION
## Summary
- verify `Assert-VersionRequirement` is invoked in BYOK and discovery-related tests
- remove TODO comments

## Testing
- `Invoke-Pester -Output Detailed -Path Tests/Get-PASBYOKConfig.Tests.ps1, Tests/Clear-PASDiscoveredLocalAccount.Tests.ps1, Tests/Set-PASIPAllowList.Tests.ps1, Tests/Get-PASDiscoveredLocalAccountActivity.Tests.ps1, Tests/Get-PASIPAllowList.Tests.ps1, Tests/Publish-PASDiscoveredLocalAccount.Tests.ps1, Tests/Remove-PASDiscoveredLocalAccount.Tests.ps1, Tests/Get-PASDiscoveredLocalAccount.Tests.ps1, Tests/Add-PASDiscoveredLocalAccount.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68409137916883308ba7cde03af6e746