### PR TITLE
Fix convert connection params

### DIFF
--- a/Tests/ConvertTo-ConnectionParam.Tests.ps1
+++ b/Tests/ConvertTo-ConnectionParam.Tests.ps1
@@ -69,14 +69,23 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
-			It 'outputs expected ConnectionParams properties' {
+                        It 'outputs expected ConnectionParams properties' {
 
-				$result = $InputObj | ConvertTo-ConnectionParam
-				$result['ConnectionParams']['PSMRemoteMachine']['Value'] | Should -Be 'RemoteMachineValue'
-				$result['ConnectionParams']['LogonDomain']['Value'] | Should -Be 'LogonDomainValue'
-				$result['SomeProperty'] | Should -Be 'SomeValue'
+                                $result = $InputObj | ConvertTo-ConnectionParam
+                                $result['ConnectionParams']['PSMRemoteMachine']['Value'] | Should -Be 'RemoteMachineValue'
+                                $result['ConnectionParams']['LogonDomain']['Value'] | Should -Be 'LogonDomainValue'
+                                $result['SomeProperty'] | Should -Be 'SomeValue'
 
-			}
+                        }
+
+                        It 'removes connection parameter properties from top level' {
+
+                                $result = $InputObj | ConvertTo-ConnectionParam
+
+                                $result.Keys | Should -Not -Contain 'PSMRemoteMachine'
+                                $result.Keys | Should -Not -Contain 'LogonDomain'
+
+                        }
 
 			It 'returns expected hashtable if no ConnectionParams are specified' {
 

--- a/psPAS/Private/ConvertTo-ConnectionParam.ps1
+++ b/psPAS/Private/ConvertTo-ConnectionParam.ps1
@@ -66,15 +66,15 @@ $output["SomeProperty"] = SomeValue
 
 				}
 
-				#Remove individual ConnectionParameters from boundParameters
-				$Parameters | Get-PASParameter -ParametersToRemove $ConnectionParameters
+                                #Remove individual ConnectionParameters from boundParameters
+                                $Parameters = $Parameters | Get-PASParameter -ParametersToRemove $ConnectionParameters
 
-			}
+                        }
 
-		}
+                }
 
-	}
+        }
 
-	End { }
+        End { $Parameters }
 
 }


### PR DESCRIPTION
## Summary
- clean connection parameter values when converting
- return cleaned hashtable
- test that connection parameters are stripped from top level

## Testing
- `Invoke-Pester -Configuration $config` for ConvertTo-ConnectionParam tests

------
https://chatgpt.com/codex/tasks/task_e_684091010cfc8330bff4d6e88a617df2